### PR TITLE
CBBD-229: Made the "primary payer code" fields optional, per the data dictionary.

### DIFF
--- a/bluebutton-data-pipeline-fhir-load/src/main/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformer.java
+++ b/bluebutton-data-pipeline-fhir-load/src/main/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformer.java
@@ -1573,8 +1573,10 @@ public final class DataTransformer {
 		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(
 				createCodeableConcept(CODING_SYSTEM_FREQUENCY_CD, String.valueOf(claimGroup.claimFrequencyCode))));
 
-		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
-				CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		if (claimGroup.claimPrimaryPayerCode.isPresent()) {
+			eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
+					CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		}
 
 		if (claimGroup.attendingPhysicianNpi.isPresent()) {
 			addCareTeamPractitioner(eob, null, CODING_SYSTEM_NPI_US, claimGroup.attendingPhysicianNpi.get(),
@@ -1803,8 +1805,10 @@ public final class DataTransformer {
 		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(
 				createCodeableConcept(CODING_SYSTEM_FREQUENCY_CD, String.valueOf(claimGroup.claimFrequencyCode))));
 
-		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
-				CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		if (claimGroup.claimPrimaryPayerCode.isPresent()) {
+			eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
+					CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		}
 
 		if (claimGroup.attendingPhysicianNpi.isPresent()) {
 			addCareTeamPractitioner(eob, null, CODING_SYSTEM_NPI_US, claimGroup.attendingPhysicianNpi.get(),
@@ -2102,8 +2106,10 @@ public final class DataTransformer {
 		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(
 				createCodeableConcept(CODING_SYSTEM_FREQUENCY_CD, String.valueOf(claimGroup.claimFrequencyCode))));
 
-		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
-				CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		if (claimGroup.claimPrimaryPayerCode.isPresent()) {
+			eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
+					CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		}
 
 		if (claimGroup.attendingPhysicianNpi.isPresent()) {
 			addCareTeamPractitioner(eob, null, CODING_SYSTEM_NPI_US, claimGroup.attendingPhysicianNpi.get(),
@@ -2464,8 +2470,10 @@ public final class DataTransformer {
 		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(
 				createCodeableConcept(CODING_SYSTEM_FREQUENCY_CD, String.valueOf(claimGroup.claimFrequencyCode))));
 
-		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
-				CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		if (claimGroup.claimPrimaryPayerCode.isPresent()) {
+			eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
+					CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		}
 
 		if (claimGroup.attendingPhysicianNpi.isPresent()) {
 			addCareTeamPractitioner(eob, null, CODING_SYSTEM_NPI_US, claimGroup.attendingPhysicianNpi.get(),
@@ -2651,8 +2659,10 @@ public final class DataTransformer {
 		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(
 				createCodeableConcept(CODING_SYSTEM_FREQUENCY_CD, String.valueOf(claimGroup.claimFrequencyCode))));
 
-		eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
-				CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		if (claimGroup.claimPrimaryPayerCode.isPresent()) {
+			eob.addInformation(new ExplanationOfBenefit.SupportingInformationComponent(createCodeableConcept(
+					CODING_SYSTEM_PRIMARY_PAYER_CD, String.valueOf(claimGroup.claimPrimaryPayerCode))));
+		}
 
 		if (claimGroup.attendingPhysicianNpi.isPresent()) {
 			addCareTeamPractitioner(eob, null, CODING_SYSTEM_NPI_US, claimGroup.attendingPhysicianNpi.get(),

--- a/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
+++ b/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
@@ -596,7 +596,7 @@ public final class RifFilesProcessor {
 		claimGroup.paymentAmount = parseDecimal(firstClaimLine.get(InpatientClaimGroup.Column.CLM_PMT_AMT));
 		claimGroup.primaryPayerPaidAmount = parseDecimal(
 				firstClaimLine.get(InpatientClaimGroup.Column.NCH_PRMRY_PYR_CLM_PD_AMT));
-		claimGroup.claimPrimaryPayerCode = parseCharacter(
+		claimGroup.claimPrimaryPayerCode = parseOptCharacter(
 				firstClaimLine.get(InpatientClaimGroup.Column.NCH_PRMRY_PYR_CD));
 		claimGroup.providerStateCode = firstClaimLine.get(InpatientClaimGroup.Column.PRVDR_STATE_CD);
 		claimGroup.organizationNpi = parseOptString(firstClaimLine.get(InpatientClaimGroup.Column.ORG_NPI_NUM));
@@ -749,7 +749,7 @@ public final class RifFilesProcessor {
 		claimGroup.paymentAmount = parseDecimal(firstClaimLine.get(OutpatientClaimGroup.Column.CLM_PMT_AMT));
 		claimGroup.primaryPayerPaidAmount = parseDecimal(
 				firstClaimLine.get(OutpatientClaimGroup.Column.NCH_PRMRY_PYR_CLM_PD_AMT));
-		claimGroup.claimPrimaryPayerCode = parseCharacter(
+		claimGroup.claimPrimaryPayerCode = parseOptCharacter(
 				firstClaimLine.get(OutpatientClaimGroup.Column.NCH_PRMRY_PYR_CD));
 		claimGroup.providerStateCode = firstClaimLine.get(OutpatientClaimGroup.Column.PRVDR_STATE_CD);
 		claimGroup.organizationNpi = parseOptString(firstClaimLine.get(OutpatientClaimGroup.Column.ORG_NPI_NUM));
@@ -1031,7 +1031,7 @@ public final class RifFilesProcessor {
 		claimGroup.paymentAmount = parseDecimal(firstClaimLine.get(SNFClaimGroup.Column.CLM_PMT_AMT));
 		claimGroup.primaryPayerPaidAmount = parseDecimal(
 				firstClaimLine.get(SNFClaimGroup.Column.NCH_PRMRY_PYR_CLM_PD_AMT));
-		claimGroup.claimPrimaryPayerCode = parseCharacter(firstClaimLine.get(SNFClaimGroup.Column.NCH_PRMRY_PYR_CD));
+		claimGroup.claimPrimaryPayerCode = parseOptCharacter(firstClaimLine.get(SNFClaimGroup.Column.NCH_PRMRY_PYR_CD));
 		claimGroup.providerStateCode = firstClaimLine.get(SNFClaimGroup.Column.PRVDR_STATE_CD);
 		claimGroup.organizationNpi = parseOptString(firstClaimLine.get(SNFClaimGroup.Column.ORG_NPI_NUM));
 		claimGroup.attendingPhysicianNpi = parseOptString(firstClaimLine.get(SNFClaimGroup.Column.AT_PHYSN_NPI));
@@ -1160,7 +1160,7 @@ public final class RifFilesProcessor {
 		claimGroup.paymentAmount = parseDecimal(firstClaimLine.get(HospiceClaimGroup.Column.CLM_PMT_AMT));
 		claimGroup.primaryPayerPaidAmount = parseDecimal(
 				firstClaimLine.get(HospiceClaimGroup.Column.NCH_PRMRY_PYR_CLM_PD_AMT));
-		claimGroup.claimPrimaryPayerCode = parseCharacter(
+		claimGroup.claimPrimaryPayerCode = parseOptCharacter(
 				firstClaimLine.get(HospiceClaimGroup.Column.NCH_PRMRY_PYR_CD));
 		claimGroup.providerStateCode = firstClaimLine.get(HospiceClaimGroup.Column.PRVDR_STATE_CD);
 		claimGroup.organizationNpi = parseOptString(firstClaimLine.get(HospiceClaimGroup.Column.ORG_NPI_NUM));
@@ -1258,7 +1258,7 @@ public final class RifFilesProcessor {
 		claimGroup.paymentAmount = parseDecimal(firstClaimLine.get(HHAClaimGroup.Column.CLM_PMT_AMT));
 		claimGroup.primaryPayerPaidAmount = parseDecimal(
 				firstClaimLine.get(HHAClaimGroup.Column.NCH_PRMRY_PYR_CLM_PD_AMT));
-		claimGroup.claimPrimaryPayerCode = parseCharacter(firstClaimLine.get(HHAClaimGroup.Column.NCH_PRMRY_PYR_CD));
+		claimGroup.claimPrimaryPayerCode = parseOptCharacter(firstClaimLine.get(HHAClaimGroup.Column.NCH_PRMRY_PYR_CD));
 		claimGroup.providerStateCode = firstClaimLine.get(HHAClaimGroup.Column.PRVDR_STATE_CD);
 		claimGroup.organizationNpi = parseOptString(firstClaimLine.get(HHAClaimGroup.Column.ORG_NPI_NUM));
 		claimGroup.attendingPhysicianNpi = parseOptString(firstClaimLine.get(HHAClaimGroup.Column.AT_PHYSN_NPI));

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/HHAClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/HHAClaimGroup.java
@@ -114,7 +114,7 @@ public final class HHAClaimGroup {
 	/**
 	 * @see Column#NCH_PRMRY_PYR_CD
 	 */
-	public Character claimPrimaryPayerCode;
+	public Optional<Character> claimPrimaryPayerCode;
 
 	/**
 	 * @see Column#PRVDR_STATE_CD

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/HospiceClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/HospiceClaimGroup.java
@@ -119,7 +119,7 @@ public final class HospiceClaimGroup {
 	/**
 	 * @see Column#NCH_PRMRY_PYR_CD
 	 */
-	public Character claimPrimaryPayerCode;
+	public Optional<Character> claimPrimaryPayerCode;
 
 	/**
 	 * @see Column#PRVDR_STATE_CD

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/InpatientClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/InpatientClaimGroup.java
@@ -119,7 +119,7 @@ public final class InpatientClaimGroup {
 	/**
 	 * @see Column#NCH_PRMRY_PYR_CD
 	 */
-	public Character claimPrimaryPayerCode;
+	public Optional<Character> claimPrimaryPayerCode;
 
 	/**
 	 * @see Column#PRVDR_STATE_CD

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/OutpatientClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/OutpatientClaimGroup.java
@@ -120,7 +120,7 @@ public final class OutpatientClaimGroup {
 	/**
 	 * @see Column#NCH_PRMRY_PYR_CD
 	 */
-	public Character claimPrimaryPayerCode;
+	public Optional<Character> claimPrimaryPayerCode;
 
 	/**
 	 * @see Column#PRVDR_STATE_CD

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/SNFClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/SNFClaimGroup.java
@@ -119,7 +119,7 @@ public final class SNFClaimGroup {
 	/**
 	 * @see Column#NCH_PRMRY_PYR_CD
 	 */
-	public Character claimPrimaryPayerCode;
+	public Optional<Character> claimPrimaryPayerCode;
 
 	/**
 	 * @see Column#PRVDR_STATE_CD


### PR DESCRIPTION
This was causing errors out in production for all of these claim types.

http://issues.hhsdevcloud.us/browse/CBBD-229