### PR TITLE
CBBD-230: Handle optional ICD codes correctly, where needed

### DIFF
--- a/bluebutton-data-pipeline-fhir-load/src/main/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformer.java
+++ b/bluebutton-data-pipeline-fhir-load/src/main/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformer.java
@@ -1106,7 +1106,9 @@ public final class DataTransformer {
 			benefitBalances.getFinancial().add(beneficiaryPartBDeductAmount);
 		}
 
-		addDiagnosisCode(eob, claimGroup.diagnosisPrincipal);
+		if (claimGroup.diagnosisPrincipal.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisPrincipal.get());
+
 		for (IcdCode diagnosis : claimGroup.diagnosesAdditional)
 			addDiagnosisCode(eob, diagnosis);
 
@@ -1287,7 +1289,8 @@ public final class DataTransformer {
 					.setReason(createCodeableConcept(CODING_SYSTEM_CMS_LINE_PROCESSING_INDICATOR,
 							claimLine.processingIndicatorCode.get()));
 
-			addDiagnosisLink(eob, item, claimLine.diagnosis);
+			if (claimLine.diagnosis.isPresent())
+				addDiagnosisLink(eob, item, claimLine.diagnosis.get());
 
 			if (claimLine.nationalDrugCode.isPresent()) {
 				addExtensionCoding(item, CODING_SYSTEM_NDC, CODING_SYSTEM_NDC, claimLine.nationalDrugCode.get());
@@ -1622,8 +1625,10 @@ public final class DataTransformer {
 					createCodeableConcept(CODING_SYSTEM_MCO_PAID_CD, String.valueOf(claimGroup.mcoPaidSw.get()))));
 		}
 
-		addDiagnosisCode(eob, claimGroup.diagnosisAdmitting);
-		addDiagnosisCode(eob, claimGroup.diagnosisPrincipal);
+		if (claimGroup.diagnosisAdmitting.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisAdmitting.get());
+		if (claimGroup.diagnosisPrincipal.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisPrincipal.get());
 		for (IcdCode diagnosis : claimGroup.diagnosesAdditional)
 			addDiagnosisCode(eob, diagnosis);
 
@@ -1856,7 +1861,8 @@ public final class DataTransformer {
 					createCodeableConcept(CODING_SYSTEM_MCO_PAID_CD, String.valueOf(claimGroup.mcoPaidSw.get()))));
 		}
 
-		addDiagnosisCode(eob, claimGroup.diagnosisPrincipal);
+		if (claimGroup.diagnosisPrincipal.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisPrincipal.get());
 		for (IcdCode diagnosis : claimGroup.diagnosesAdditional)
 			addDiagnosisCode(eob, diagnosis);
 
@@ -2317,7 +2323,8 @@ public final class DataTransformer {
 		eob.addInformation().setCategory(
 				createCodeableConcept(CODING_SYSTEM_ADMISSION_TYPE_CD, String.valueOf(claimGroup.admissionTypeCd)));
 
-		addDiagnosisCode(eob, claimGroup.diagnosisAdmitting);
+		if (claimGroup.diagnosisAdmitting.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisAdmitting.get());
 		addDiagnosisCode(eob, claimGroup.diagnosisPrincipal);
 		for (IcdCode diagnosis : claimGroup.diagnosesAdditional)
 			addDiagnosisCode(eob, diagnosis);
@@ -2515,7 +2522,8 @@ public final class DataTransformer {
 					CARE_TEAM_ROLE_PRIMARY);
 		}
 
-		addDiagnosisCode(eob, claimGroup.diagnosisPrincipal);
+		if (claimGroup.diagnosisPrincipal.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisPrincipal.get());
 		for (IcdCode diagnosis : claimGroup.diagnosesAdditional)
 			addDiagnosisCode(eob, diagnosis);
 
@@ -2954,8 +2962,8 @@ public final class DataTransformer {
 			benefitBalances.getFinancial().add(beneficiaryPartBDeductAmount);
 		}
 
-
-		addDiagnosisCode(eob, claimGroup.diagnosisPrincipal);
+		if (claimGroup.diagnosisPrincipal.isPresent())
+			addDiagnosisCode(eob, claimGroup.diagnosisPrincipal.get());
 		for (IcdCode diagnosis : claimGroup.diagnosesAdditional)
 			addDiagnosisCode(eob, diagnosis);
 
@@ -3110,7 +3118,8 @@ public final class DataTransformer {
 						String.valueOf(claimLine.serviceDeductibleCode.get()));
 			}
 
-			addDiagnosisLink(eob, item, claimLine.diagnosis);
+			if (claimLine.diagnosis.isPresent())
+				addDiagnosisLink(eob, item, claimLine.diagnosis.get());
 
 			item.addAdjudication()
 					.setCategory(createCodeableConcept(CODING_SYSTEM_ADJUDICATION_CMS,

--- a/bluebutton-data-pipeline-fhir-load/src/test/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformerTest.java
+++ b/bluebutton-data-pipeline-fhir-load/src/test/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformerTest.java
@@ -1977,6 +1977,21 @@ public final class DataTransformerTest {
 	}
 
 	/**
+	 * @param expectedDiagnosis
+	 *            the expected {@link IcdCode} to verify the presence of in the
+	 *            {@link ItemComponent}
+	 * @param eob
+	 *            the {@link ExplanationOfBenefit} to verify
+	 * @param eobItem
+	 *            the {@link ItemComponent} to verify
+	 */
+	private static void assertDiagnosisLinkPresent(Optional<IcdCode> expectedDiagnosis, ExplanationOfBenefit eob,
+			ItemComponent eobItem) {
+		if (expectedDiagnosis.isPresent())
+			assertDiagnosisLinkPresent(expectedDiagnosis.get(), eob, eobItem);
+	}
+
+	/**
 	 * @param expectedSystem
 	 *            the expected {@link Identifier#getSystem()} value
 	 * @param expectedId

--- a/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
+++ b/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
@@ -668,9 +668,9 @@ public final class RifFilesProcessor {
 
 		claimGroup.diagnosisRelatedGroupCd = parseOptString(firstClaimLine.get(InpatientClaimGroup.Column.CLM_DRG_CD));
 
-		claimGroup.diagnosisAdmitting = parseIcdCode(firstClaimLine.get(InpatientClaimGroup.Column.ADMTG_DGNS_CD),
+		claimGroup.diagnosisAdmitting = parseOptIcdCode(firstClaimLine.get(InpatientClaimGroup.Column.ADMTG_DGNS_CD),
 				firstClaimLine.get(InpatientClaimGroup.Column.ADMTG_DGNS_VRSN_CD));
-		claimGroup.diagnosisPrincipal = parseIcdCode(firstClaimLine.get(InpatientClaimGroup.Column.PRNCPAL_DGNS_CD),
+		claimGroup.diagnosisPrincipal = parseOptIcdCode(firstClaimLine.get(InpatientClaimGroup.Column.PRNCPAL_DGNS_CD),
 				firstClaimLine.get(InpatientClaimGroup.Column.PRNCPAL_DGNS_VRSN_CD));
 		claimGroup.diagnosesAdditional = parseIcdCodesWithPOA(firstClaimLine,
 				InpatientClaimGroup.Column.ICD_DGNS_CD1.ordinal(),
@@ -767,7 +767,7 @@ public final class RifFilesProcessor {
 				firstClaimLine.get(OutpatientClaimGroup.Column.NCH_BENE_BLOOD_DDCTBL_LBLTY_AM));
 		claimGroup.professionalComponentCharge = parseDecimal(
 				firstClaimLine.get(OutpatientClaimGroup.Column.NCH_PROFNL_CMPNT_CHRG_AMT));
-		claimGroup.diagnosisPrincipal = parseIcdCode(firstClaimLine.get(OutpatientClaimGroup.Column.PRNCPAL_DGNS_CD),
+		claimGroup.diagnosisPrincipal = parseOptIcdCode(firstClaimLine.get(OutpatientClaimGroup.Column.PRNCPAL_DGNS_CD),
 				firstClaimLine.get(OutpatientClaimGroup.Column.PRNCPAL_DGNS_VRSN_CD));
 		claimGroup.diagnosesAdditional = parseIcdCodes(firstClaimLine,
 				OutpatientClaimGroup.Column.ICD_DGNS_CD1.ordinal(),
@@ -911,7 +911,7 @@ public final class RifFilesProcessor {
 				firstClaimLine.get(CarrierClaimGroup.Column.CARR_CLM_CASH_DDCTBL_APLD_AMT));
 		claimGroup.hcpcsYearCode = parseOptCharacter(firstClaimLine.get(CarrierClaimGroup.Column.CARR_CLM_HCPCS_YR_CD));
 		claimGroup.referringProviderIdNumber = firstClaimLine.get(CarrierClaimGroup.Column.CARR_CLM_RFRNG_PIN_NUM);
-		claimGroup.diagnosisPrincipal = parseIcdCode(firstClaimLine.get(CarrierClaimGroup.Column.PRNCPAL_DGNS_CD),
+		claimGroup.diagnosisPrincipal = parseOptIcdCode(firstClaimLine.get(CarrierClaimGroup.Column.PRNCPAL_DGNS_CD),
 				firstClaimLine.get(CarrierClaimGroup.Column.PRNCPAL_DGNS_VRSN_CD));
 		claimGroup.diagnosesAdditional = parseIcdCodes(firstClaimLine, CarrierClaimGroup.Column.ICD_DGNS_CD1.ordinal(),
 				CarrierClaimGroup.Column.ICD_DGNS_VRSN_CD12.ordinal());
@@ -978,7 +978,7 @@ public final class RifFilesProcessor {
 					claimLineRecord.get(CarrierClaimGroup.Column.LINE_SERVICE_DEDUCTIBLE));
 			claimLine.mtusCount = parseDecimal(claimLineRecord.get(CarrierClaimGroup.Column.CARR_LINE_MTUS_CNT));
 			claimLine.mtusCode = parseOptCharacter(claimLineRecord.get(CarrierClaimGroup.Column.CARR_LINE_MTUS_CD));
-			claimLine.diagnosis = parseIcdCode(claimLineRecord.get(CarrierClaimGroup.Column.LINE_ICD_DGNS_CD),
+			claimLine.diagnosis = parseOptIcdCode(claimLineRecord.get(CarrierClaimGroup.Column.LINE_ICD_DGNS_CD),
 					claimLineRecord.get(CarrierClaimGroup.Column.LINE_ICD_DGNS_VRSN_CD));
 			claimLine.hpsaScarcityCode = parseOptCharacter(
 					claimLineRecord.get(CarrierClaimGroup.Column.HPSA_SCRCTY_IND_CD));
@@ -1088,7 +1088,7 @@ public final class RifFilesProcessor {
 
 		claimGroup.diagnosisRelatedGroupCd = parseOptString(firstClaimLine.get(SNFClaimGroup.Column.CLM_DRG_CD));
 
-		claimGroup.diagnosisAdmitting = parseIcdCode(firstClaimLine.get(SNFClaimGroup.Column.ADMTG_DGNS_CD),
+		claimGroup.diagnosisAdmitting = parseOptIcdCode(firstClaimLine.get(SNFClaimGroup.Column.ADMTG_DGNS_CD),
 				firstClaimLine.get(SNFClaimGroup.Column.ADMTG_DGNS_VRSN_CD));
 		claimGroup.diagnosisPrincipal = parseIcdCode(firstClaimLine.get(SNFClaimGroup.Column.PRNCPAL_DGNS_CD),
 				firstClaimLine.get(SNFClaimGroup.Column.PRNCPAL_DGNS_VRSN_CD));
@@ -1175,7 +1175,7 @@ public final class RifFilesProcessor {
 		claimGroup.utilizationDayCount = parseInt(firstClaimLine.get(HospiceClaimGroup.Column.CLM_UTLZTN_DAY_CNT));
 		claimGroup.beneficiaryDischargeDate = parseOptDate(
 				firstClaimLine.get(HospiceClaimGroup.Column.NCH_BENE_DSCHRG_DT));
-		claimGroup.diagnosisPrincipal = parseIcdCode(firstClaimLine.get(HospiceClaimGroup.Column.PRNCPAL_DGNS_CD),
+		claimGroup.diagnosisPrincipal = parseOptIcdCode(firstClaimLine.get(HospiceClaimGroup.Column.PRNCPAL_DGNS_CD),
 				firstClaimLine.get(HospiceClaimGroup.Column.PRNCPAL_DGNS_VRSN_CD));
 		claimGroup.diagnosesAdditional = parseIcdCodes(firstClaimLine, HospiceClaimGroup.Column.ICD_DGNS_CD1.ordinal(),
 				HospiceClaimGroup.Column.ICD_DGNS_VRSN_CD25.ordinal());
@@ -1366,7 +1366,7 @@ public final class RifFilesProcessor {
 		claimGroup.beneficiaryPartBDeductAmount = parseDecimal(
 				firstClaimLine.get(DMEClaimGroup.Column.CARR_CLM_CASH_DDCTBL_APLD_AMT));
 		claimGroup.hcpcsYearCode = parseOptCharacter(firstClaimLine.get(DMEClaimGroup.Column.CARR_CLM_HCPCS_YR_CD));
-		claimGroup.diagnosisPrincipal = parseIcdCode(firstClaimLine.get(DMEClaimGroup.Column.PRNCPAL_DGNS_CD),
+		claimGroup.diagnosisPrincipal = parseOptIcdCode(firstClaimLine.get(DMEClaimGroup.Column.PRNCPAL_DGNS_CD),
 				firstClaimLine.get(DMEClaimGroup.Column.PRNCPAL_DGNS_VRSN_CD));
 		claimGroup.diagnosesAdditional = parseIcdCodes(firstClaimLine, DMEClaimGroup.Column.ICD_DGNS_CD1.ordinal(),
 				DMEClaimGroup.Column.ICD_DGNS_VRSN_CD12.ordinal());
@@ -1420,7 +1420,7 @@ public final class RifFilesProcessor {
 			claimLine.paymentCode = parseOptCharacter(claimLineRecord.get(DMEClaimGroup.Column.LINE_PMT_80_100_CD));
 			claimLine.serviceDeductibleCode = parseOptCharacter(
 					claimLineRecord.get(DMEClaimGroup.Column.LINE_SERVICE_DEDUCTIBLE));
-			claimLine.diagnosis = parseIcdCode(claimLineRecord.get(DMEClaimGroup.Column.LINE_ICD_DGNS_CD),
+			claimLine.diagnosis = parseOptIcdCode(claimLineRecord.get(DMEClaimGroup.Column.LINE_ICD_DGNS_CD),
 					claimLineRecord.get(DMEClaimGroup.Column.LINE_ICD_DGNS_VRSN_CD));
 			claimLine.purchasePriceAmount = parseDecimal(
 					claimLineRecord.get(DMEClaimGroup.Column.LINE_DME_PRCHS_PRICE_AMT));

--- a/bluebutton-data-pipeline-rif-extract/src/test/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessorTest.java
+++ b/bluebutton-data-pipeline-rif-extract/src/test/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessorTest.java
@@ -241,7 +241,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(new BigDecimal("0"), claimGroup.beneficiaryPartBDeductAmount);
 		Assert.assertEquals(new Character('5'), claimGroup.hcpcsYearCode.get());
 		Assert.assertEquals("K25852", claimGroup.referringProviderIdNumber);
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "H33333"), claimGroup.diagnosisPrincipal);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "H33333"), claimGroup.diagnosisPrincipal.get());
 		Assert.assertEquals(4, claimGroup.diagnosesAdditional.size());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "H44444"), claimGroup.diagnosesAdditional.get(0));
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "H55555"), claimGroup.diagnosesAdditional.get(1));
@@ -289,7 +289,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(new Character('0'), claimLine.serviceDeductibleCode.get());
 		Assert.assertEquals(new BigDecimal("1"), claimLine.mtusCount);
 		Assert.assertEquals(new Character('3'), claimLine.mtusCode.get());
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "H12345"), claimLine.diagnosis);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "H12345"), claimLine.diagnosis.get());
 		Assert.assertFalse(claimLine.hpsaScarcityCode.isPresent());
 		Assert.assertFalse(claimLine.rxNumber.isPresent());
 		Assert.assertEquals(new BigDecimal("42.0"), claimLine.hctHgbTestResult);
@@ -386,8 +386,8 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(LocalDate.of(2016, 1, 27), claimGroup.beneficiaryDischargeDate.get());
 		Assert.assertEquals(new BigDecimal("23.99"), claimGroup.nchDrugOutlierApprovedPaymentAmount.get());
 		
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R4444"), claimGroup.diagnosisAdmitting);
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R5555"), claimGroup.diagnosisPrincipal);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R4444"), claimGroup.diagnosisAdmitting.get());
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R5555"), claimGroup.diagnosisPrincipal.get());
 		Assert.assertEquals(5, claimGroup.diagnosesAdditional.size());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R6666", "Y"), claimGroup.diagnosesAdditional.get(0));
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "A7777", "N"), claimGroup.diagnosesAdditional.get(1));
@@ -467,7 +467,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(new BigDecimal("8888.85"), claimGroup.totalChargeAmount);
 		Assert.assertEquals(new BigDecimal("6.00"), claimGroup.bloodDeductibleLiabilityAmount);
 		Assert.assertEquals(new BigDecimal("66.89"), claimGroup.professionalComponentCharge);
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R5555"), claimGroup.diagnosisPrincipal);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R5555"), claimGroup.diagnosisPrincipal.get());
 		Assert.assertEquals(2, claimGroup.diagnosesAdditional.size());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "R8888"), claimGroup.diagnosesAdditional.get(0));
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "I9999"), claimGroup.diagnosesAdditional.get(1));
@@ -579,7 +579,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(LocalDate.of(2002, 1, 31), claimGroup.medicareBenefitsExhaustedDate.get());
 		Assert.assertEquals(LocalDate.of(2013, 12, 18), claimGroup.beneficiaryDischargeDate.get());
 
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "V11111"), claimGroup.diagnosisAdmitting);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "V11111"), claimGroup.diagnosisAdmitting.get());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "V22222"), claimGroup.diagnosisPrincipal);
 		Assert.assertEquals(1, claimGroup.diagnosesAdditional.size());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "V44444"), claimGroup.diagnosisFirstClaimExternal.get());
@@ -656,7 +656,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(new Character('C'), claimGroup.patientStatusCd.get());
 		Assert.assertEquals(new Integer(30), claimGroup.utilizationDayCount);
 		Assert.assertEquals(LocalDate.of(2015, 6, 29), claimGroup.beneficiaryDischargeDate.get());
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "33444"), claimGroup.diagnosisPrincipal);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "33444"), claimGroup.diagnosisPrincipal.get());
 		Assert.assertEquals(1, claimGroup.diagnosesAdditional.size());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_9, "55555"), claimGroup.diagnosesAdditional.get(0));
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "999888"), claimGroup.diagnosisFirstClaimExternal.get());
@@ -814,7 +814,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals(new BigDecimal("754.79"), claimGroup.allowedChargeAmount);
 		Assert.assertEquals(new BigDecimal("0"), claimGroup.beneficiaryPartBDeductAmount);
 		Assert.assertEquals(new Character('3'), claimGroup.hcpcsYearCode.get());
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "222333"), claimGroup.diagnosisPrincipal);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "222333"), claimGroup.diagnosisPrincipal.get());
 		Assert.assertEquals(1, claimGroup.diagnosesAdditional.size());
 		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "444555"), claimGroup.diagnosesAdditional.get(0));
 		Assert.assertEquals("222333222", claimGroup.referringPhysicianNpi.get());
@@ -851,7 +851,7 @@ public final class RifFilesProcessorTest {
 		Assert.assertEquals("A", claimLine.processingIndicatorCode.get());
 		Assert.assertEquals(new Character('0'), claimLine.paymentCode.get());
 		Assert.assertEquals(new Character('0'), claimLine.serviceDeductibleCode.get());
-		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "G6666"), claimLine.diagnosis);
+		Assert.assertEquals(new IcdCode(IcdVersion.ICD_10, "G6666"), claimLine.diagnosis.get());
 		Assert.assertEquals(new BigDecimal("82.29"), claimLine.purchasePriceAmount);
 		Assert.assertEquals("1244444444", claimLine.providerNPI);
 		Assert.assertEquals("AL", claimLine.pricingStateCode.get());

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/CarrierClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/CarrierClaimGroup.java
@@ -160,7 +160,7 @@ public final class CarrierClaimGroup {
 	 * @see Column#PRNCPAL_DGNS_CD
 	 * @see Column#PRNCPAL_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisPrincipal;
+	public Optional<IcdCode> diagnosisPrincipal;
 
 	/**
 	 * See {@link Column#ICD_DGNS_CD1} through {@link Column#ICD_DGNS_CD12} and
@@ -444,7 +444,7 @@ public final class CarrierClaimGroup {
 		 * @see Column#LINE_ICD_DGNS_CD
 		 * @see Column#LINE_ICD_DGNS_VRSN_CD
 		 */
-		public IcdCode diagnosis;
+		public Optional<IcdCode> diagnosis;
 
 		/**
 		 * @see Column#HPSA_SCRCTY_IND_CD

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/DMEClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/DMEClaimGroup.java
@@ -145,7 +145,7 @@ public final class DMEClaimGroup {
 	 * @see Column#PRNCPAL_DGNS_CD
 	 * @see Column#PRNCPAL_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisPrincipal;
+	public Optional<IcdCode> diagnosisPrincipal;
 
 	/**
 	 * See {@link Column#ICD_DGNS_CD1} through {@link Column#ICD_DGNS_CD12} and
@@ -381,7 +381,7 @@ public final class DMEClaimGroup {
 		 * @see Column#LINE_ICD_DGNS_CD
 		 * @see Column#LINE_ICD_DGNS_VRSN_CD
 		 */
-		public IcdCode diagnosis;
+		public Optional<IcdCode> diagnosis;
 
 		/**
 		 * @see Column#LINE_DME_PRCHS_PRICE_AMT

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/HospiceClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/HospiceClaimGroup.java
@@ -165,7 +165,7 @@ public final class HospiceClaimGroup {
 	 * @see Column#PRNCPAL_DGNS_CD
 	 * @see Column#PRNCPAL_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisPrincipal;
+	public Optional<IcdCode> diagnosisPrincipal;
 
 	/**
 	 * See {@link Column#ICD_DGNS_CD1} through {@link Column#ICD_DGNS_CD25} and

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/InpatientClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/InpatientClaimGroup.java
@@ -312,13 +312,13 @@ public final class InpatientClaimGroup {
 	 * @see Column#ADMTG_DGNS_CD
 	 * @see Column#ADMTG_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisAdmitting;
+	public Optional<IcdCode> diagnosisAdmitting;
 
 	/**
 	 * @see Column#PRNCPAL_DGNS_CD
 	 * @see Column#PRNCPAL_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisPrincipal;
+	public Optional<IcdCode> diagnosisPrincipal;
 
 	/**
 	 * See {@link Column#ICD_DGNS_CD1} through {@link Column#ICD_DGNS_CD25} and

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/OutpatientClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/OutpatientClaimGroup.java
@@ -176,7 +176,7 @@ public final class OutpatientClaimGroup {
 	 * @see Column#PRNCPAL_DGNS_CD
 	 * @see Column#PRNCPAL_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisPrincipal;
+	public Optional<IcdCode> diagnosisPrincipal;
 
 	/**
 	 * See {@link Column#ICD_DGNS_CD1} through {@link Column#ICD_DGNS_CD25} and

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/SNFClaimGroup.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/SNFClaimGroup.java
@@ -300,7 +300,7 @@ public final class SNFClaimGroup {
 	 * @see Column#ADMTG_DGNS_CD
 	 * @see Column#ADMTG_DGNS_VRSN_CD
 	 */
-	public IcdCode diagnosisAdmitting;
+	public Optional<IcdCode> diagnosisAdmitting;
 
 	/**
 	 * @see Column#PRNCPAL_DGNS_CD


### PR DESCRIPTION
The decision on which ICD codes should be optional and which shouldn't came from the documentation that was produced for CBBD-96, and is further documented in this issue's comments.

http://issues.hhsdevcloud.us/browse/CBBD-230