### PR TITLE
Allow invalid ICD version codes.

### DIFF
--- a/bluebutton-data-pipeline-fhir-load/src/test/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformerTest.java
+++ b/bluebutton-data-pipeline-fhir-load/src/test/java/gov/hhs/cms/bluebutton/datapipeline/fhir/transform/DataTransformerTest.java
@@ -734,13 +734,13 @@ public final class DataTransformerTest {
 
 		Assert.assertEquals(9, eob.getDiagnosis().size());
 
-		assertHasCoding(record.procedureCodes.get(0).getVersion().getFhirSystem(),
+		assertHasCoding(DataTransformer.computeFhirSystem(record.procedureCodes.get(0)),
 				record.procedureCodes.get(0).getCode(),
 				eob.getProcedure().get(0).getProcedureCodeableConcept());
 		Assert.assertEquals(Date
 				.from(record.procedureCodes.get(0).getProcedureDate().atStartOfDay(ZoneId.systemDefault()).toInstant()),
 				eob.getProcedure().get(0).getDate());
-		assertHasCoding(record.procedureCodes.get(1).getVersion().getFhirSystem(),
+		assertHasCoding(DataTransformer.computeFhirSystem(record.procedureCodes.get(1)),
 				record.procedureCodes.get(1).getCode(), eob.getProcedure().get(1).getProcedureCodeableConcept());
 		Assert.assertEquals(Date
 				.from(record.procedureCodes.get(1).getProcedureDate().atStartOfDay(ZoneId.systemDefault()).toInstant()),
@@ -882,7 +882,7 @@ public final class DataTransformerTest {
 
 		Assert.assertEquals(6, eob.getDiagnosis().size());
 		Assert.assertEquals(1, eob.getProcedure().size());
-		assertHasCoding(record.procedureCodes.get(0).getVersion().getFhirSystem(),
+		assertHasCoding(DataTransformer.computeFhirSystem(record.procedureCodes.get(0)),
 				record.procedureCodes.get(0).getCode(), eob.getProcedure().get(0).getProcedureCodeableConcept());
 		Assert.assertEquals(Date
 				.from(record.procedureCodes.get(0).getProcedureDate().atStartOfDay(ZoneId.systemDefault()).toInstant()),
@@ -1098,7 +1098,7 @@ public final class DataTransformerTest {
 						String.valueOf(record.diagnosisRelatedGroupCd.get()))));
 
 		Assert.assertEquals(5, eob.getDiagnosis().size());
-		assertHasCoding(record.procedureCodes.get(0).getVersion().getFhirSystem(),
+		assertHasCoding(DataTransformer.computeFhirSystem(record.procedureCodes.get(0)),
 				record.procedureCodes.get(0).getCode(), eob.getProcedure().get(0).getProcedureCodeableConcept());
 		Assert.assertEquals(Date
 				.from(record.procedureCodes.get(0).getProcedureDate().atStartOfDay(ZoneId.systemDefault()).toInstant()),
@@ -1946,7 +1946,7 @@ public final class DataTransformerTest {
 		Optional<DiagnosisComponent> eobDiagnosis = eob.getDiagnosis().stream()
 				.filter(d -> d.getDiagnosis() instanceof CodeableConcept)
 				.filter(d -> DataTransformer.isCodeInConcept((CodeableConcept) d.getDiagnosis(),
-						expectedDiagnosis.getVersion().getFhirSystem(), expectedDiagnosis.getCode()))
+						DataTransformer.computeFhirSystem(expectedDiagnosis), expectedDiagnosis.getCode()))
 				.findAny();
 		Assert.assertTrue(eobDiagnosis.isPresent());
 		Assert.assertTrue(eobItem.getDiagnosisLinkId().stream()

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/CodedValue.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/CodedValue.java
@@ -1,0 +1,105 @@
+package gov.hhs.cms.bluebutton.datapipeline.rif.model;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.justdavis.karl.misc.exceptions.BadCodeMonkeyException;
+
+/**
+ * Associates a raw RIF value with its (hopefully) decoded {@link Enum}
+ * constant.
+ * 
+ * @param <V>
+ *            the raw value type coming in from RIF
+ * @param <C>
+ *            the {@link Enum} type that the values can be decoded into
+ */
+public final class CodedValue<V, C> {
+	private final V rawValue;
+	private final Optional<C> decodedValue;
+
+	/**
+	 * Constructs a new {@link CodedValue} instance
+	 * 
+	 * @param rawValue
+	 *            the value to use for {@link #getRawValue()}
+	 * @param decoder
+	 *            {@link Function} that can be used to decode
+	 *            {@link #getRawValue()} into {@link #getDecodedValue()}
+	 */
+	public CodedValue(V rawValue, Function<V, Optional<C>> decoder) {
+		if (decoder == null)
+			throw new BadCodeMonkeyException();
+
+		this.rawValue = rawValue;
+		this.decodedValue = decoder.apply(rawValue);
+	}
+
+	/**
+	 * @return the raw value coming in from RIF, which may be <code>null</code>
+	 *         or an empty value or really anything
+	 */
+	public V getRawValue() {
+		return rawValue;
+	}
+
+	/**
+	 * @return the {@link Enum} value that {@link #getRawValue()} was decoded
+	 *         into, or {@link Optional#empty()} if it could not be decoded
+	 */
+	public Optional<C> getDecodedValue() {
+		return decodedValue;
+	}
+
+	/**
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((decodedValue == null) ? 0 : decodedValue.hashCode());
+		result = prime * result + ((rawValue == null) ? 0 : rawValue.hashCode());
+		return result;
+	}
+
+	/**
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@SuppressWarnings("rawtypes")
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CodedValue other = (CodedValue) obj;
+		if (decodedValue == null) {
+			if (other.decodedValue != null)
+				return false;
+		} else if (!decodedValue.equals(other.decodedValue))
+			return false;
+		if (rawValue == null) {
+			if (other.rawValue != null)
+				return false;
+		} else if (!rawValue.equals(other.rawValue))
+			return false;
+		return true;
+	}
+
+	/**
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("CodedValue [rawValue=");
+		builder.append(rawValue);
+		builder.append(", decodedValue=");
+		builder.append(decodedValue);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/IcdCode.java
+++ b/bluebutton-data-pipeline-rif/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/model/IcdCode.java
@@ -1,12 +1,13 @@
 package gov.hhs.cms.bluebutton.datapipeline.rif.model;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 /**
  * A simple struct for modeling ICD codes, as stored in the CCW.
  */
 public final class IcdCode {
-	private final IcdVersion version;
+	private final CodedValue<String, IcdVersion> version;
 	private final String code;
 	private final String presentOnAdmission;
 	private final LocalDate procedureDate;
@@ -18,26 +19,68 @@ public final class IcdCode {
 	 *            the value to use for {@link #getVersion()}
 	 * @param code
 	 *            the value to use for {@link #getCode()}
-	 * @param code
-	 *            the value to use for {@link #getPresentOnAdmission()}
-	 * @param code
-	 *            the value to use for {@link #getProcedureDate()}
 	 */
-	public IcdCode(IcdVersion version, String code) {
+	public IcdCode(CodedValue<String, IcdVersion> version, String code) {
 		this.version = version;
 		this.code = code;
 		this.presentOnAdmission = "";
 		this.procedureDate = null;
 	}
 
-	public IcdCode(IcdVersion version, String code, String presentOnAdmission) {
+	/**
+	 * Constructs a new {@link IcdCode} instance.
+	 * 
+	 * @param version
+	 *            the value to use for {@link #getVersion()}
+	 * @param code
+	 *            the value to use for {@link #getCode()}
+	 */
+	public IcdCode(IcdVersion version, String code) {
+		this(version.toCodedValue(), code);
+	}
+
+	/**
+	 * Constructs a new {@link IcdCode} instance.
+	 * 
+	 * @param version
+	 *            the value to use for {@link #getVersion()}
+	 * @param code
+	 *            the value to use for {@link #getCode()}
+	 * @param presentOnAdmission
+	 *            the value to use for {@link #getPresentOnAdmission()}
+	 */
+	public IcdCode(CodedValue<String, IcdVersion> version, String code, String presentOnAdmission) {
 		this.version = version;
 		this.code = code;
 		this.presentOnAdmission = presentOnAdmission;
 		this.procedureDate = null;
 	}
 
-	public IcdCode(IcdVersion version, String code, LocalDate procedureDate) {
+	/**
+	 * Constructs a new {@link IcdCode} instance.
+	 * 
+	 * @param version
+	 *            the value to use for {@link #getVersion()}
+	 * @param code
+	 *            the value to use for {@link #getCode()}
+	 * @param presentOnAdmission
+	 *            the value to use for {@link #getPresentOnAdmission()}
+	 */
+	public IcdCode(IcdVersion version, String code, String presentOnAdmission) {
+		this(version.toCodedValue(), code, presentOnAdmission);
+	}
+
+	/**
+	 * Constructs a new {@link IcdCode} instance.
+	 * 
+	 * @param version
+	 *            the value to use for {@link #getVersion()}
+	 * @param code
+	 *            the value to use for {@link #getCode()}
+	 * @param procedureDate
+	 *            the value to use for {@link #getProcedureDate()}
+	 */
+	public IcdCode(CodedValue<String, IcdVersion> version, String code, LocalDate procedureDate) {
 		this.version = version;
 		this.code = code;
 		this.procedureDate = procedureDate;
@@ -45,9 +88,23 @@ public final class IcdCode {
 	}
 
 	/**
+	 * Constructs a new {@link IcdCode} instance.
+	 * 
+	 * @param version
+	 *            the value to use for {@link #getVersion()}
+	 * @param code
+	 *            the value to use for {@link #getCode()}
+	 * @param procedureDate
+	 *            the value to use for {@link #getProcedureDate()}
+	 */
+	public IcdCode(IcdVersion version, String code, LocalDate procedureDate) {
+		this(version.toCodedValue(), code, procedureDate);
+	}
+
+	/**
 	 * @return the {@link IcdVersion} of this {@link IcdCode}
 	 */
-	public IcdVersion getVersion() {
+	public CodedValue<String, IcdVersion> getVersion() {
 		return version;
 	}
 
@@ -62,7 +119,7 @@ public final class IcdCode {
 	 * @return the ICD present on admission value
 	 */
 	public String getPresentOnAdmission() {
-			return presentOnAdmission;
+		return presentOnAdmission;
 	}
 
 	/**
@@ -101,7 +158,7 @@ public final class IcdCode {
 				return false;
 		} else if (!code.equals(other.code))
 			return false;
-		if (version != other.version)
+		if (!version.equals(other.version))
 			return false;
 		return true;
 	}
@@ -145,10 +202,12 @@ public final class IcdCode {
 		 *            "https://www.ccwdata.org/cs/groups/public/documents/datadictionary/prncpal_dgns_vrsn_cd.txt">
 		 *            CCW Data Dictionary: PRNCPAL_DGNS_VRSN_CD</a> and other
 		 *            similar fields
-		 * @param fhirCodingSystem the value to use for {@link #getFhirSystem()}
+		 * @param fhirCodingSystem
+		 *            the value to use for {@link #getFhirSystem()}
 		 */
 		private IcdVersion(String ccwCoding, String fhirCodingSystem) {
-			this.ccwCoding = ccwCoding;this.fhirCodingSystem = fhirCodingSystem;
+			this.ccwCoding = ccwCoding;
+			this.fhirCodingSystem = fhirCodingSystem;
 		}
 
 		/**
@@ -161,6 +220,28 @@ public final class IcdCode {
 		}
 
 		/**
+		 * @return test helper that converts a fixed {@link IcdVersion} into a
+		 *         {@link CodedValue}
+		 */
+		public CodedValue<String, IcdVersion> toCodedValue() {
+			return parse(ccwCoding);
+		}
+
+		/**
+		 * @param ccwCoding
+		 *            the CCW ICD version coding value to be parsed, which must
+		 *            conform to the coding used in <a href=
+		 *            "https://www.ccwdata.org/cs/groups/public/documents/datadictionary/prncpal_dgns_vrsn_cd.txt">
+		 *            CCW Data Dictionary: PRNCPAL_DGNS_VRSN_CD</a> and other
+		 *            similar fields
+		 * @return the parsed {@link CodedValue} represented by the specified
+		 *         value
+		 */
+		public static CodedValue<String, IcdVersion> parse(String ccwCoding) {
+			return new CodedValue<String, IcdVersion>(ccwCoding, IcdVersion::parseRaw);
+		}
+
+		/**
 		 * @param ccwCoding
 		 *            the CCW ICD version coding value to be parsed, which must
 		 *            conform to the coding used in <a href=
@@ -170,12 +251,16 @@ public final class IcdCode {
 		 * @return the parsed {@link IcdVersion} represented by the specified
 		 *         value
 		 */
-		public static IcdVersion parse(String ccwCoding) {
+		private static Optional<IcdVersion> parseRaw(String ccwCoding) {
 			for (IcdVersion icdVersion : IcdVersion.values())
 				if (icdVersion.ccwCoding.equals(ccwCoding))
-					return icdVersion;
+					return Optional.of(icdVersion);
 
-			throw new IllegalArgumentException("Unknown value: " + ccwCoding);
+			/*
+			 * I haven't seen this in the production data, but our dummy data
+			 * doesn't have proper ICD version values -- just random ones.
+			 */
+			return Optional.empty();
 		}
 	}
 }


### PR DESCRIPTION
These appear a lot in the dummy sample data, and needed to be supported. If we ever get sample data where this isn't the case, we can consider removing this support.

http://issues.hhsdevcloud.us/browse/CBBD-243