### PR TITLE
No longer build the executable capsule JAR

### DIFF
--- a/bluebutton-data-pipeline-app/pom.xml
+++ b/bluebutton-data-pipeline-app/pom.xml
@@ -89,7 +89,12 @@
 					<artifactId>capsule-maven-plugin</artifactId>
 					<configuration>
 						<appClass>gov.hhs.cms.bluebutton.datapipeline.app.S3ToFhirLoadApp</appClass>
-						<chmod>true</chmod>
+
+						<!-- Building the "really executable" .x files is tempting, but ultimately 
+							not very useful, as there's no way to pass JVM args into such launchers, 
+							which prevents customizing the heap size at runtime. -->
+						<chmod>false</chmod>
+
 						<types>fat</types>
 						<manifest>
 							<entry>
@@ -101,20 +106,6 @@
 								<value>1.8.0</value>
 							</entry>
 						</manifest>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>org.codehaus.mojo</groupId>
-					<artifactId>build-helper-maven-plugin</artifactId>
-					<version>1.12</version>
-					<configuration>
-						<artifacts>
-							<artifact>
-								<file>${project.build.directory}/${project.artifactId}-${project.version}-capsule-fat.x</file>
-								<type>x</type>
-								<classifier>capsule-fat</classifier>
-							</artifact>
-						</artifacts>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -129,19 +120,6 @@
 					<execution>
 						<goals>
 							<goal>build</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-capsule-x</id>
-						<phase>package</phase>
-						<goals>
-							<goal>attach-artifact</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/S3ToFhirLoadAppIT.java
+++ b/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/S3ToFhirLoadAppIT.java
@@ -355,12 +355,15 @@ public final class S3ToFhirLoadAppIT {
 	 */
 	private static String[] createCommandForCapsule() {
 		try {
-			Path buildTargetDir = Paths.get(".", "target");
-			Path appExe = Files.list(buildTargetDir)
-					.filter(f -> f.getFileName().toString().startsWith("bluebutton-data-pipeline-app-"))
-					.filter(f -> f.getFileName().toString().endsWith("-capsule-fat.x")).findFirst().get();
+			Path javaBinDir = Paths.get(System.getProperty("java.home")).resolve("bin");
+			Path javaBin = javaBinDir.resolve("java");
 
-			return new String[] { appExe.toAbsolutePath().toString() };
+			Path buildTargetDir = Paths.get(".", "target");
+			Path appJar = Files.list(buildTargetDir)
+					.filter(f -> f.getFileName().toString().startsWith("bluebutton-data-pipeline-app-"))
+					.filter(f -> f.getFileName().toString().endsWith("-capsule-fat.jar")).findFirst().get();
+
+			return new String[] { javaBin.toString(), "-jar", appJar.toAbsolutePath().toString() };
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
http://issues.hhsdevcloud.us/browse/CBBD-252

While running in the dummy sample data, I needed to adjust the max heap size, but couldn't with the executable capsule JAR. Turns out that the executable capsule JARs don't allow any JVM parameters to be specified at runtime; those params all have to be specified at build time.

That doesn't meet our needs, so we should axe these build artifacts.

Note that the non-executable "fat" capsule JARs do not have this limitation; we can just use them everywhere, instead.