### PR TITLE
CBBI-267: Renamed AppConfigurationTest.java to AppConfigurationTestIT…

### DIFF
--- a/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/AppConfigurationTestIT.java
+++ b/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/AppConfigurationTestIT.java
@@ -28,7 +28,7 @@ import gov.hhs.cms.bluebutton.data.pipeline.rif.load.RifLoaderTestUtils;
  * an application in a separate process.
  * </p>
  */
-public final class AppConfigurationTest {
+public final class AppConfigurationTestIT {
 	/**
 	 * Verifies that
 	 * {@link AppConfiguration#readConfigFromEnvironmentVariables()} works as
@@ -129,7 +129,7 @@ public final class AppConfigurationTest {
 		Path java = Paths.get(System.getProperty("java.home")).resolve("bin").resolve("java");
 		String classpath = System.getProperty("java.class.path");
 		ProcessBuilder testAppBuilder = new ProcessBuilder(java.toAbsolutePath().toString(), "-classpath", classpath,
-				AppConfigurationTest.class.getName());
+				AppConfigurationTestIT.class.getName());
 		return testAppBuilder;
 	}
 


### PR DESCRIPTION
….java and fixed up class name in code.  This change allows the test to be skipped with the -DskipITs build parameter as it does use AWS credentials.  This will eliminate any confusion for users when building as it now matches what is documented in the development docs.