### PR TITLE
CBBD-366: Added back in the HICN hashing unit tests

### DIFF
--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
@@ -559,7 +559,7 @@ public final class RifLoader {
 				.time();
 
 		Beneficiary beneficiary = (Beneficiary) rifRecordEvent.getRecord();
-		beneficiary.setHicn(computeHicnHash(beneficiary.getHicn()));
+		beneficiary.setHicn(computeHicnHash(options, secretKeyFactory, beneficiary.getHicn()));
 
 		timerHashing.stop();
 	}
@@ -568,7 +568,7 @@ public final class RifLoader {
 	 * @return a new {@link SecretKeyFactory} for the
 	 *         <code>PBKDF2WithHmacSHA256</code> algorithm
 	 */
-	private static SecretKeyFactory createSecretKeyFactory() {
+	static SecretKeyFactory createSecretKeyFactory() {
 		try {
 			return SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
 		} catch (NoSuchAlgorithmException e) {
@@ -584,12 +584,14 @@ public final class RifLoader {
 	 * 
 	 * @param options
 	 *            the {@link LoadAppOptions} to use
+	 * @param secretKeyFactory
+	 *            the {@link SecretKeyFactory} to use
 	 * @param hicn
 	 *            the Medicare beneficiary HICN to be hashed
 	 * @return a one-way cryptographic hash of the specified HICN value, exactly
 	 *         64 characters long
 	 */
-	private String computeHicnHash(String hicn) {
+	static String computeHicnHash(LoadAppOptions options, SecretKeyFactory secretKeyFactory, String hicn) {
 		try {
 			/*
 			 * Our approach here is NOT using a salt, as salts must be randomly

--- a/bluebutton-data-pipeline-rif-load/src/test/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTest.java
+++ b/bluebutton-data-pipeline-rif-load/src/test/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTest.java
@@ -1,0 +1,43 @@
+package gov.hhs.cms.bluebutton.data.pipeline.rif.load;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import javax.crypto.SecretKeyFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit tests for {@link RifLoader}.
+ */
+public final class RifLoaderTest {
+	private static final Logger LOGGER = LoggerFactory.getLogger(RifLoaderTest.class);
+
+	/**
+	 * Runs a couple of fake HICNs through
+	 * {@link RifLoader#computeHicnHash(LoadAppOptions, SecretKeyFactory, String)}
+	 * to verify that the expected result is produced.
+	 */
+	@Test
+	public void computeHicnHash() {
+		LoadAppOptions options = RifLoaderTestUtils.getLoadOptions();
+		options = new LoadAppOptions(1000, "nottherealpepper".getBytes(StandardCharsets.UTF_8),
+				options.getDatabaseUrl(), options.getDatabaseUsername(), options.getDatabasePassword(),
+				options.getLoaderThreads());
+		LOGGER.info("salt/pepper: {}", Arrays.toString("nottherealpepper".getBytes(StandardCharsets.UTF_8)));
+		LOGGER.info("hash iterations: {}", 1000);
+		SecretKeyFactory secretKeyFactory = RifLoader.createSecretKeyFactory();
+
+		/*
+		 * These are the two samples from `dev/design-decisions-readme.md` that
+		 * the frontend and backend both have tests to verify the result of.
+		 */
+		Assert.assertEquals("d95a418b0942c7910fb1d0e84f900fe12e5a7fd74f312fa10730cc0fda230e9a",
+				RifLoader.computeHicnHash(options, secretKeyFactory, "123456789A"));
+		Assert.assertEquals("6357f16ebd305103cf9f2864c56435ad0de5e50f73631159772f4a4fcdfe39a5",
+				RifLoader.computeHicnHash(options, secretKeyFactory, "987654321E"));
+	}
+}


### PR DESCRIPTION
Had been accidentally removed in the switch from FHIR loading to JPA.

https://issues.hhsdevcloud.us/browse/CBBD-366