### PR TITLE
CBBI-288: Fixed the HSQL config used in tests

### DIFF
--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTestUtils.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTestUtils.java
@@ -42,18 +42,27 @@ public final class RifLoaderTestUtils {
 	public static final byte[] HICN_HASH_PEPPER = "nottherealpepper".getBytes(StandardCharsets.UTF_8);
 
 	/**
+	 * <p>
 	 * The value to use for {@link LoadAppOptions#getDatabaseUrl()}. It's
 	 * occasionally useful for devs to manually change this to one of these
 	 * values:
+	 * </p>
 	 * <ul>
 	 * <li>In-memory HSQL DB (this is the default):
-	 * <code>jdbc:hsqldb:mem:test</code></li>
+	 * <code>jdbc:hsqldb:mem:test;hsqldb.tx=mvcc</code></li>
 	 * <li>On-disk HSQL DB (useful when the in-memory DB is running out of
 	 * memory):
-	 * <code>jdbc:hsqldb:file:target/hsql-db-for-its;hsqldb.tx=locks</code></li>
+	 * <code>jdbc:hsqldb:file:target/hsql-db-for-its;hsqldb.tx=mvcc</code></li>
 	 * </ul>
+	 * <p>
+	 * Note: The <code>hsqldb.tx=mvcc</code> option included in the URL is
+	 * needed to avoid locking problems with some concurrent tests that access
+	 * the DB. See
+	 * <a href="http://hsqldb.org/doc/guide/sessions-chapt.html#snc_tx_mvcc">
+	 * HSQL DB: MVCC</a> for details.
+	 * </p>
 	 */
-	public static final String DB_URL = "jdbc:hsqldb:mem:test;hsqldb.tx=locks";
+	public static final String DB_URL = "jdbc:hsqldb:mem:test;hsqldb.tx=mvcc";
 
 	/**
 	 * The value to use for {@link LoadAppOptions#getDatabaseUsername()}.


### PR DESCRIPTION
The git commit entry on the previous version makes me think that I oopsed: I'd meant to set it this was in that earlier commit.

Added some extra documentation explaining the config, because I'm tired of having to look it up every time I see it and wonder why I set it that way.

Note: This isn't really related to CBBI-288: I just happened to notice the discrepancy while working on it.