### PR TITLE
BLUEBUTTON-186: Data Pipeline: Catch and persist HICN/bene history data to DB

### DIFF
--- a/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
+++ b/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
@@ -20,6 +20,8 @@ import com.codahale.metrics.Timer;
 import com.justdavis.karl.misc.exceptions.BadCodeMonkeyException;
 
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
+import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
+import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistoryParser;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryParser;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaimParser;
@@ -78,6 +80,9 @@ public final class RifFilesProcessor {
 		if (file.getFileType() == RifFileType.BENEFICIARY) {
 			isGrouped = false;
 			recordParser = RifFilesProcessor::buildBeneficiaryEvent;
+		} else if (file.getFileType() == RifFileType.BENEFICIARY_HISTORY) {
+			isGrouped = false;
+			recordParser = RifFilesProcessor::buildBeneficiaryHistoryEvent;
 		} else if (file.getFileType() == RifFileType.PDE) {
 			isGrouped = false;
 			recordParser = RifFilesProcessor::buildPartDEvent;
@@ -166,6 +171,29 @@ public final class RifFilesProcessor {
 		RecordAction recordAction = RecordAction.match(csvRecord.get("DML_IND"));
 		Beneficiary beneficiaryRow = BeneficiaryParser.parseRif(csvRecords);
 		return new RifRecordEvent<Beneficiary>(fileEvent, recordAction, beneficiaryRow);
+	}
+
+	/**
+	 * @param fileEvent
+	 *            the {@link RifFileEvent} being processed
+	 * @param csvRecords
+	 *            the {@link CSVRecord} to be mapped (in a single-element
+	 *            {@link List}), which must be from a
+	 *            {@link RifFileType#BENEFICIARY_HISTORY} {@link RifFile}
+	 * @return a {@link RifRecordEvent} built from the specified {@link CSVRecord}s
+	 */
+	private static RifRecordEvent<BeneficiaryHistory> buildBeneficiaryHistoryEvent(RifFileEvent fileEvent,
+			List<CSVRecord> csvRecords) {
+		if (csvRecords.size() != 1)
+			throw new BadCodeMonkeyException();
+		CSVRecord csvRecord = csvRecords.get(0);
+
+		if (LOGGER.isTraceEnabled())
+			LOGGER.trace(csvRecord.toString());
+
+		RecordAction recordAction = RecordAction.match(csvRecord.get("DML_IND"));
+		BeneficiaryHistory beneficiaryHistoryRow = BeneficiaryHistoryParser.parseRif(csvRecords);
+		return new RifRecordEvent<BeneficiaryHistory>(fileEvent, recordAction, beneficiaryHistoryRow);
 	}
 
 	/**


### PR DESCRIPTION
The historical HICNs are needed by the Data Server, as they will allow it to improve how often it can successfully match/link records requested by the frontend. This is due to MyMedicare/SLS not sending benes' current HICNs, but instead an arbitrary and possibly old one.

The solution here has two parts:

1. For initial loads and backfills: Process a full dump of the bene history data from the CCW.
2. For ongoing ops: Every time a bene is updated, write out its old state to the bene history table in our DB, to ensure older HICNs aren't forgotten.

https://jira.cms.gov/browse/BLUEBUTTON-186