### PR TITLE
BLUEBUTTON-260: Fix LoadStrategy selection for UPDATE records

### DIFF
--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
@@ -495,18 +495,7 @@ public final class RifLoader {
 							 * current/previous state as a BeneficiaryHistory record.
 							 */
 							if (record instanceof Beneficiary) {
-								Beneficiary newBene = (Beneficiary) record;
-								Beneficiary oldBene = entityManager.find(Beneficiary.class, newBene.getBeneficiaryId());
-
-								if (oldBene != null) {
-									BeneficiaryHistory oldBeneCopy = new BeneficiaryHistory();
-									oldBeneCopy.setBeneficiaryId(oldBene.getBeneficiaryId());
-									oldBeneCopy.setBirthDate(oldBene.getBirthDate());
-									oldBeneCopy.setHicn(oldBene.getHicn());
-									oldBeneCopy.setSex(oldBene.getSex());
-
-									entityManager.persist(oldBeneCopy);
-								}
+								updateBeneficaryHistory(entityManager, (Beneficiary) record);
 							}
 
 							entityManager.merge(record);
@@ -559,6 +548,31 @@ public final class RifLoader {
 
 			if (entityManager != null)
 				entityManager.close();
+		}
+	}
+
+	/**
+	 * Ensures that a {@link BeneficiaryHistory} record is created for the specified
+	 * {@link Beneficiary}, if that {@link Beneficiary} already exists and is just
+	 * being updated.
+	 *
+	 * @param entityManager
+	 *            the {@link EntityManager} to use
+	 * @param newBeneficiaryRecord
+	 *            the {@link Beneficiary} record being processed
+	 */
+	private static void updateBeneficaryHistory(EntityManager entityManager, Beneficiary newBeneficiaryRecord) {
+		Beneficiary oldBeneficiaryRecord = entityManager.find(Beneficiary.class,
+				newBeneficiaryRecord.getBeneficiaryId());
+
+		if (oldBeneficiaryRecord != null) {
+			BeneficiaryHistory oldBeneCopy = new BeneficiaryHistory();
+			oldBeneCopy.setBeneficiaryId(oldBeneficiaryRecord.getBeneficiaryId());
+			oldBeneCopy.setBirthDate(oldBeneficiaryRecord.getBirthDate());
+			oldBeneCopy.setHicn(oldBeneficiaryRecord.getHicn());
+			oldBeneCopy.setSex(oldBeneficiaryRecord.getSex());
+
+			entityManager.persist(oldBeneCopy);
 		}
 	}
 

--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
@@ -419,7 +419,7 @@ public final class RifLoader {
 		MetricRegistry fileEventMetrics = fileEvent.getEventMetrics();
 
 		// TODO make the features configurable
-		LoadFeatures features = new LoadFeatures(false, false);
+		LoadFeatures features = new LoadFeatures(true, false);
 
 		RifFileType rifFileType = fileEvent.getFile().getFileType();
 


### PR DESCRIPTION
Turns out, it was opting to completely skip UPDATE records if `LoadFeatures.isIdempotencyRequired()` was `true`. Whoops!

Thankfully, we haven't tried to run in that mode since we finished the initial load, so this hasn't blown up in our faces.

As always, please see the individual commit messages for an explanation of what's happening here.

https://jira.cms.gov/browse/BLUEBUTTON-260