### PR TITLE
BLUEBUTTON-467: Make idempotency a configurable option

### DIFF
--- a/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/AppConfigurationTestIT.java
+++ b/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/AppConfigurationTestIT.java
@@ -61,6 +61,7 @@ public final class AppConfigurationTestIT {
 		testAppBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_DATABASE_PASSWORD,
 				String.valueOf(RifLoaderTestUtils.DB_PASSWORD));
 		testAppBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_LOADER_THREADS, "42");
+		testAppBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_IDEMPOTENCY_REQUIRED, "true");
 		Process testApp = testAppBuilder.start();
 
 		int testAppExitCode = testApp.waitFor();
@@ -97,6 +98,9 @@ public final class AppConfigurationTestIT {
 		Assert.assertEquals(
 				Integer.parseInt(testAppBuilder.environment().get(AppConfiguration.ENV_VAR_KEY_LOADER_THREADS)),
 				testAppConfig.getLoadOptions().getLoaderThreads());
+		Assert.assertEquals(AppConfiguration
+				.parseBoolean(testAppBuilder.environment().get(AppConfiguration.ENV_VAR_KEY_IDEMPOTENCY_REQUIRED))
+				.get(), testAppConfig.getLoadOptions().isIdempotencyRequired());
 	}
 
 	/**

--- a/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/S3ToDatabaseLoadAppIT.java
+++ b/bluebutton-data-pipeline-app/src/test/java/gov/hhs/cms/bluebutton/datapipeline/app/S3ToDatabaseLoadAppIT.java
@@ -359,6 +359,8 @@ public final class S3ToDatabaseLoadAppIT {
 				String.valueOf(RifLoaderTestUtils.DB_PASSWORD));
 		appRunBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_LOADER_THREADS,
 				String.valueOf(LoadAppOptions.DEFAULT_LOADER_THREADS));
+		appRunBuilder.environment().put(AppConfiguration.ENV_VAR_KEY_IDEMPOTENCY_REQUIRED,
+				String.valueOf(RifLoaderTestUtils.IDEMPOTENCY_REQUIRED));
 		/*
 		 * Note: Not explicitly providing AWS credentials here, as the child
 		 * process will inherit any that are present in this build/test process.

--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/LoadAppOptions.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/LoadAppOptions.java
@@ -26,6 +26,7 @@ public final class LoadAppOptions implements Serializable {
 	private final String databaseUsername;
 	private final char[] databasePassword;
 	private final int loaderThreads;
+	private final boolean idempotencyRequired;
 
 	/**
 	 * Constructs a new {@link LoadAppOptions} instance.
@@ -42,9 +43,11 @@ public final class LoadAppOptions implements Serializable {
 	 *            the value to use for {@link #getDatabasePassword()}
 	 * @param loaderThreads
 	 *            the value to use for {@link #getLoaderThreads()}
+	 * @param idempotencyRequired
+	 *            the value to use for {@link #isIdempotencyRequired()}
 	 */
 	public LoadAppOptions(int hicnHashIterations, byte[] hicnHashPepper, String databaseUrl, String databaseUsername,
-			char[] databasePassword, int loaderThreads) {
+			char[] databasePassword, int loaderThreads, boolean idempotencyRequired) {
 		if (loaderThreads < 1)
 			throw new IllegalArgumentException();
 
@@ -54,6 +57,7 @@ public final class LoadAppOptions implements Serializable {
 		this.databaseUsername = databaseUsername;
 		this.databasePassword = databasePassword;
 		this.loaderThreads = loaderThreads;
+		this.idempotencyRequired = idempotencyRequired;
 	}
 
 	/**
@@ -99,6 +103,24 @@ public final class LoadAppOptions implements Serializable {
 	 */
 	public int getLoaderThreads() {
 		return loaderThreads;
+	}
+
+	/**
+	 * @return
+	 *         <p>
+	 *         <code>true</code> if {@link RifLoader} should check to see if each
+	 *         record has already been processed, <code>false</code> if it should
+	 *         blindly assume that it hasn't
+	 *         </p>
+	 *         <p>
+	 *         This is sometimes a reasonable speed vs. safety tradeoff to make, as
+	 *         that checking is slow, particularly if indexes have been dropped in
+	 *         an attempt to speed up initial loads. Aside from that, though, this
+	 *         value is best left set to <code>true</code>.
+	 *         </p>
+	 */
+	public boolean isIdempotencyRequired() {
+		return idempotencyRequired;
 	}
 
 	/**

--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTestUtils.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTestUtils.java
@@ -74,6 +74,11 @@ public final class RifLoaderTestUtils {
 	 */
 	public static final char[] DB_PASSWORD = "".toCharArray();
 
+	/**
+	 * The value to use for {@link LoadAppOptions#isIdempotencyRequired()}.
+	 */
+	public static final boolean IDEMPOTENCY_REQUIRED = true;
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(RifLoaderTestUtils.class);
 
 	/**
@@ -143,7 +148,7 @@ public final class RifLoaderTestUtils {
 	 */
 	public static LoadAppOptions getLoadOptions() {
 		return new LoadAppOptions(HICN_HASH_ITERATIONS, HICN_HASH_PEPPER, DB_URL, DB_USERNAME, DB_PASSWORD,
-				LoadAppOptions.DEFAULT_LOADER_THREADS);
+				LoadAppOptions.DEFAULT_LOADER_THREADS, IDEMPOTENCY_REQUIRED);
 	}
 
 	/**

--- a/bluebutton-data-pipeline-rif-load/src/test/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTest.java
+++ b/bluebutton-data-pipeline-rif-load/src/test/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderTest.java
@@ -26,7 +26,7 @@ public final class RifLoaderTest {
 		LoadAppOptions options = RifLoaderTestUtils.getLoadOptions();
 		options = new LoadAppOptions(1000, "nottherealpepper".getBytes(StandardCharsets.UTF_8),
 				options.getDatabaseUrl(), options.getDatabaseUsername(), options.getDatabasePassword(),
-				options.getLoaderThreads());
+				options.getLoaderThreads(), options.isIdempotencyRequired());
 		LOGGER.info("salt/pepper: {}", Arrays.toString("nottherealpepper".getBytes(StandardCharsets.UTF_8)));
 		LOGGER.info("hash iterations: {}", 1000);
 		SecretKeyFactory secretKeyFactory = RifLoader.createSecretKeyFactory();


### PR DESCRIPTION
We use the non-idempotent mode for initial loads. Previously, I'd just been using custom builds where the `LoadFeature` for it was hardcoded the way we needed it. That's not a workable approach long-term.

Eventually, it'd be good if idempotent vs. non-idempotent mode could be automagically configured at runtime by looking at whether the data set has already been loaded or not, but that's not possible right now.

https://jira.cms.gov/browse/BLUEBUTTON-467