### PR TITLE
BLUEBUTTON-526: Updated Jenkinsfile for best practices

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+#!/usr/bin/env groovy
+
 /**
  * <p>
  * This is the script that will be run by Jenkins to build and test this 
@@ -14,8 +16,18 @@
  * </p>
  */
 
-node {
-	stage('Checkout') {
+properties([
+	pipelineTriggers([
+		triggers: [[
+			$class: 'jenkins.triggers.ReverseBuildTrigger',
+			upstreamProjects: "bluebutton-parent-pom/master,bluebutton-data-model/master", threshold: hudson.model.Result.SUCCESS
+		]]
+	]),
+	buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: ''))
+])
+
+stage('Checkout') {
+	node {
 		// Grab the commit that triggered the build.
 		checkout scm
 
@@ -23,12 +35,18 @@ node {
 		// are distinguishable from other builds.
 		setPomVersionUsingBuildId()
 	}
+}
 
-	stage('Build') {
+stage('Build') {
+	node {
+		milestone(label: 'stage_build_start')
+
 		mvn "--update-snapshots -Dmaven.test.failure.ignore clean install"
 	}
+}
 
-	stage('Archive') {
+stage('Archive') {
+	node {
 		// Fingerprint the output artifacts and archive the test results.
 		// (Archiving the artifacts here would waste space, as the build
 		// deploys them to the local Maven repository.)
@@ -38,6 +56,7 @@ node {
 		archiveArtifacts artifacts: '**/target/*-reports/*.txt', allowEmptyArchive: true
 	}
 }
+
 
 /**
  * Runs Maven with the specified arguments.


### PR DESCRIPTION
Addressed these things:

1. Add a shebang to the top, for IDE syntax and formatting assistance.
2. Setup a reverse trigger to build when dependencies are updated.
3. Try to explicitly disable discarding old builds.
4. Don't keep `node`s busy for longer than necessary.
5. Don't build old commits if newer ones have already been (via `milestone`s).

https://jira.cms.gov/browse/BLUEBUTTON-526