### PR TITLE
Bluebutton-842:  Terminate ETL process if incorrect version in manifest

### DIFF
--- a/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/s3/DataSetQueue.java
+++ b/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/s3/DataSetQueue.java
@@ -42,18 +42,6 @@ public final class DataSetQueue {
 	private final S3TaskManager s3TaskManager;
 
 	/**
-	 * This {@link System#exit(int)} value should be used when the manifest RIF
-	 * version number is incorrect
-	 */
-	static final int EXIT_CODE_INCORRECT_MANIFEST_FORMAT = 1;
-
-	/**
-	 * This {@link System#exit(int)} value should be used when the manifest RIF file
-	 * type is incorrect
-	 */
-	static final int EXIT_CODE_INCORRECT_MANIFEST_RIF_FILE_TYPE = 2;
-
-	/**
 	 * The {@link DataSetManifest}s waiting to be processed, ordered by their
 	 * {@link DataSetManifestId} in ascending order such that the first element
 	 * represents the {@link DataSetManifest} that should be processed next.


### PR DESCRIPTION
Purpose of this PR is to have the ETL load process stop/abend if it encounters any manifests with an incorrect version number from our code.    Previously; the code skipped the "bad" version manifest file and continued onto the other manifest files.   