### PR TITLE
Bluebutton-928: rename bene history temp table to bene history

### DIFF
--- a/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
+++ b/bluebutton-data-pipeline-rif-extract/src/main/java/gov/hhs/cms/bluebutton/datapipeline/rif/extract/RifFilesProcessor.java
@@ -22,8 +22,6 @@ import com.justdavis.karl.misc.exceptions.BadCodeMonkeyException;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistoryParser;
-import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistoryTemp;
-import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistoryTempParser;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryParser;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaimParser;
@@ -87,9 +85,6 @@ public final class RifFilesProcessor {
 		} else if (file.getFileType() == RifFileType.BENEFICIARY_HISTORY) {
 			isGrouped = false;
 			recordParser = RifFilesProcessor::buildBeneficiaryHistoryEvent;
-		} else if (file.getFileType() == RifFileType.BENEFICIARY_HISTORY_TEMP) {
-			isGrouped = false;
-			recordParser = RifFilesProcessor::buildBeneficiaryHistoryTempEvent;
 		} else if (file.getFileType() == RifFileType.MEDICARE_BENEFICIARY_ID_HISTORY) {
 			isGrouped = false;
 			recordParser = RifFilesProcessor::buildMedicareBeneficiaryIdHistoryEvent;
@@ -181,29 +176,6 @@ public final class RifFilesProcessor {
 		RecordAction recordAction = RecordAction.match(csvRecord.get("DML_IND"));
 		Beneficiary beneficiaryRow = BeneficiaryParser.parseRif(csvRecords);
 		return new RifRecordEvent<Beneficiary>(fileEvent, recordAction, beneficiaryRow);
-	}
-
-	/**
-	 * @param fileEvent
-	 *            the {@link RifFileEvent} being processed
-	 * @param csvRecords
-	 *            the {@link CSVRecord} to be mapped (in a single-element
-	 *            {@link List}), which must be from a
-	 *            {@link RifFileType#BENEFICIARY_HISTORY_TEMP} {@link RifFile}
-	 * @return a {@link RifRecordEvent} built from the specified {@link CSVRecord}s
-	 */
-	private static RifRecordEvent<BeneficiaryHistoryTemp> buildBeneficiaryHistoryTempEvent(RifFileEvent fileEvent,
-			List<CSVRecord> csvRecords) {
-		if (csvRecords.size() != 1)
-			throw new BadCodeMonkeyException();
-		CSVRecord csvRecord = csvRecords.get(0);
-
-		if (LOGGER.isTraceEnabled())
-			LOGGER.trace(csvRecord.toString());
-
-		RecordAction recordAction = RecordAction.match(csvRecord.get("DML_IND"));
-		BeneficiaryHistoryTemp beneficiaryHistoryTempRow = BeneficiaryHistoryTempParser.parseRif(csvRecords);
-		return new RifRecordEvent<BeneficiaryHistoryTemp>(fileEvent, recordAction, beneficiaryHistoryTempRow);
 	}
 
 	/**

--- a/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
+++ b/bluebutton-data-pipeline-rif-load/src/main/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoader.java
@@ -59,7 +59,6 @@ import com.zaxxer.hikari.pool.HikariProxyConnection;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryCsvWriter;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
-import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistoryTemp;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaimCsvWriter;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaimLine;
@@ -425,9 +424,6 @@ public final class RifLoader {
 		} else if (rifFileType == RifFileType.BENEFICIARY_HISTORY) {
 			for (RifRecordEvent<?> rifRecordEvent : recordsBatch)
 				hashBeneficiaryHistoryHicn(fileEventMetrics, rifRecordEvent);
-		} else if (rifFileType == RifFileType.BENEFICIARY_HISTORY_TEMP) {
-			for (RifRecordEvent<?> rifRecordEvent : recordsBatch)
-				hashBeneficiaryHistoryTempHicn(fileEventMetrics, rifRecordEvent);
 		}
 
 		// Only one of each failure/success Timer.Contexts will be applied.
@@ -671,42 +667,6 @@ public final class RifLoader {
 
 		// set the hashed Hicn
 		beneficiaryHistory.setHicn(computeHicnHash(options, secretKeyFactory, beneficiaryHistory.getHicn()));
-
-		timerHashing.stop();
-	}
-
-	/**
-	 * <p>
-	 * For {@link RifRecordEvent}s where the {@link RifRecordEvent#getRecord()} is a
-	 * {@link BeneficiaryHistoryTemp}, switches the
-	 * {@link BeneficiaryHistoryTemp#getHicn()} property to a cryptographic hash of
-	 * its current value. This is done for security purposes, and the Blue Button
-	 * API frontend applications know how to compute the exact same hash, which
-	 * allows the two halves of the system to interoperate.
-	 * </p>
-	 * <p>
-	 * All other {@link RifRecordEvent}s are left unmodified.
-	 * </p>
-	 *
-	 * @param metrics
-	 *            the {@link MetricRegistry} to use
-	 * @param rifRecordEvent
-	 *            the {@link RifRecordEvent} to (possibly) modify
-	 */
-	private void hashBeneficiaryHistoryTempHicn(MetricRegistry metrics, RifRecordEvent<?> rifRecordEvent) {
-		if (rifRecordEvent.getFileEvent().getFile().getFileType() != RifFileType.BENEFICIARY_HISTORY_TEMP)
-			return;
-
-		Timer.Context timerHashing = metrics.timer(MetricRegistry.name(getClass().getSimpleName(), "hicnsHashed"))
-				.time();
-
-		BeneficiaryHistoryTemp beneficiaryHistoryTemp = (BeneficiaryHistoryTemp) rifRecordEvent.getRecord();
-
-		// set the unhashed Hicn
-		beneficiaryHistoryTemp.setHicnUnhashed(Optional.of(beneficiaryHistoryTemp.getHicn()));
-
-		// set the hashed Hicn
-		beneficiaryHistoryTemp.setHicn(computeHicnHash(options, secretKeyFactory, beneficiaryHistoryTemp.getHicn()));
 
 		timerHashing.stop();
 	}


### PR DESCRIPTION
Needed to remove all the code that created the BeneficiariesHistoryTemp table as this project would not build correctly as it was looking for the BeneficiariesHistoryTemp table from the entity class.