### PR TITLE
BLUEBUTTON-734: Add tests for SAMPLE_MCT_UPDATE_3

### DIFF
--- a/bluebutton-data-pipeline-rif-load/src/test/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderIT.java
+++ b/bluebutton-data-pipeline-rif-load/src/test/java/gov/hhs/cms/bluebutton/data/pipeline/rif/load/RifLoaderIT.java
@@ -134,6 +134,7 @@ public final class RifLoaderIT {
 		loadSample(StaticRifResourceGroup.SAMPLE_MCT);
 		loadSample(StaticRifResourceGroup.SAMPLE_MCT_UPDATE_1);
 		loadSample(StaticRifResourceGroup.SAMPLE_MCT_UPDATE_2);
+		loadSample(StaticRifResourceGroup.SAMPLE_MCT_UPDATE_3);
 	}
 
 	/**


### PR DESCRIPTION
Just adding Data Pipeline IT coverage for the new sample data from https://github.com/CMSgov/bluebutton-data-model/pull/73, to ensure that it loads as expected.

Note that the build for this PR will not pass until the other one is merged, but it does build for me locally.

https://jira.cms.gov/browse/BLUEBUTTON-734